### PR TITLE
do not use absolute path to fortune

### DIFF
--- a/src/sig_file.c
+++ b/src/sig_file.c
@@ -171,9 +171,9 @@ appendFortune(dstrbuf *app)
 
 	/* set IFS and PATH environment variable for security reasons */
 	putenv("IFS=' '");
-	putenv("PATH='/usr/bin:/usr/local/bin:/usr/games'");
-	if (!(fortune = popen("/usr/games/fortune", "r"))) {
-		warning("Could not exectute /usr/games/fortune");
+	putenv("PATH=/usr/bin:/usr/local/bin:/usr/games");
+	if (!(fortune = popen("fortune", "r"))) {
+		warning("Could not exectute fortune");
 		dsbPrintf(app, "Unspecified Fortune");
 		return;
 	}
@@ -191,8 +191,8 @@ appendFortune(dstrbuf *app)
 
 
 /**
- * AppendSig will append the signature file and take into 
- * account the wildcards allowed to be specified and transform 
+ * AppendSig will append the signature file and take into
+ * account the wildcards allowed to be specified and transform
  * them to the correct modules.
 **/
 int


### PR DESCRIPTION
Here is a patch to use the fortune executable which might not be under `/usr/games`.

By using an absolute path, there was no reason to set the `PATH` variable too.

So, using just the executable name with no path, releaved another bug.
There is not need to use `'` (single quotes) around the paths set with `putenv`.
Using single quotes around the paths, makes the the argument be though as a complete path, so the system tries to find executables under `'/usr/bin:/usr/local/bin:/usr/games'` and not under the different paths (it thinks it is one path).

So, all in all this makes the `%f` in the signature usable in systems that do not place the fortune executable under `/usr/games` and fixes the `PATH` variable setting.

Thanks ;) 
