### PR TITLE
&'s showing in man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ A: Yes! Email does `SMTP AUTH`.  You will need to set a few options in the `emai
 
 ####Q: Can I join the development team?
 
-A: Yes, send an email at http://www.cleancode.org/projects/email and ask how, or just clone it with git (see above on how to do that) and start coding and committing!
+A: Yes, send an email at http://deanproxy.com/contact/ and ask how, or just clone it with git (see above on how to do that) and start coding and committing!
 
 ---
 
@@ -263,9 +263,11 @@ My initial purpose was to make e-mail easier to send via command line and encryp
 
 A: Dean Jones - Main developer
 
+http://deanproxy.com/contact/
+
 That's about it so far. 
 I hope you like the program `eMail`.
 
-If you have any questions, bugs, or concerns email us at:
+If you have any questions, bugs, or concerns please use:
 
-http://www.cleancode.org/projects/email/contact
+https://github.com/deanproxy/eMail/issues

--- a/email.1.in
+++ b/email.1.in
@@ -63,7 +63,7 @@ help section.
 
 The Help is not statically programmed into email.
 Instead it is a file in email's home directory called
-&'email.help'.  It is updated regularly and will always
+\&'email.help'.  It is updated regularly and will always
 be rewritten with every release of email.
 
 .TP
@@ -349,7 +349,7 @@ this variable is not set, it will default to vi.
 TMPDIR can be set to specify a temporary directory to
 place your temp files while email is working.  This is
 analogous to the TEMP_DIR variable in email.conf.  
-&'email' will check TEMP_DIR first, then check your 
+\&'email' will check TEMP_DIR first, then check your 
 environment variable TMPDIR for a temporary directory.
 If neither contains a value, email defaults to /tmp.
 

--- a/email.1.in
+++ b/email.1.in
@@ -452,16 +452,16 @@ email \-s "files attached" Dean,Jeff --attach stuff.tar.gz,readme.doc
 
 If you find any in this program, please submit them to 
 .TP
-.B http://www.cleancode.org/projects/email/contact
+.B https://github.com/deanproxy/eMail/issues
 
 .SH AUTHORS
 
-.B Dean Jones   - http://www.cleancode.org/projects/email/contact
+.B Dean Jones   - http://deanproxy.com/contact/
 
 .SH THANKS FOR RELEASE V3.0
 .B Philip Lewis - Helped in debugging.
 
 .SH COPYRIGHT
 
-.B (C) 2001 - 2008
+.B (C) 2001 - 2016
 

--- a/email.sig
+++ b/email.sig
@@ -1,7 +1,7 @@
 
 --
 Sent using Email %v
-http://www.cleancode.org/projects/email
+http://deanproxy.com/code/
 
 Sent on: %c
 On System: %h

--- a/include/addr_parse.h
+++ b/include/addr_parse.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/addy_book.h
+++ b/include/addy_book.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/conf.h
+++ b/include/conf.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/email.h
+++ b/include/email.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/error.h
+++ b/include/error.h
@@ -3,7 +3,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2004 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/execgpg.h
+++ b/include/execgpg.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/file_io.h
+++ b/include/file_io.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/message.h
+++ b/include/message.h
@@ -3,7 +3,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2004 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/mimeutils.h
+++ b/include/mimeutils.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/processmail.h
+++ b/include/processmail.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/progress_bar.h
+++ b/include/progress_bar.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/remotesmtp.h
+++ b/include/remotesmtp.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/sig_file.h
+++ b/include/sig_file.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ help ()
 {
     cat <<EOF
 This script is witten and maintained by Dean Jones.
-Please send bugs to <dean@cleancode.org>
+Please report bugs using https://github.com/deanproxy/eMail/issues
 Options are described below.
 
     --prefix dir            Specifies the main prefix to all directories
@@ -254,13 +254,13 @@ fi
 echo " Success!"
 cat << EOF
 
-#######################################################
-# Done installing E-Mail client.                      #
-# Please read README for information on setup and use.#
-#                                                     #
-# If you have any questions or concerns...            #
-# Please e-mail: software@cleancode.org               #
-#######################################################
+#########################################################
+# Done installing E-Mail client.                        #
+# Please read README for information on setup and use.  #
+#                                                       #
+# If you have any questions or concerns...              #
+# Please use: https://github.com/deanproxy/eMail/issues #
+#########################################################
 EOF
 
 

--- a/src/addr_parse.c
+++ b/src/addr_parse.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/addy_book.c
+++ b/src/addy_book.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/email.c
+++ b/src/email.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/error.c
+++ b/src/error.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/execgpg.c
+++ b/src/execgpg.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/message.c
+++ b/src/message.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/mimeutils.c
+++ b/src/mimeutils.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/processmail.c
+++ b/src/processmail.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/progress_bar.c
+++ b/src/progress_bar.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/remotesmtp.c
+++ b/src/remotesmtp.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/sig_file.c
+++ b/src/sig_file.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -2,7 +2,7 @@
     eMail is a command line SMTP client.
 
     Copyright (C) 2001 - 2008 email by Dean Jones
-    Software supplied and written by http://www.cleancode.org
+    Software supplied and written by http://deanproxy.com/
 
     This file is part of eMail.
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,7 +5,7 @@ help ()
 cat <<EOF
 
 This script is written and maintained by Dean Jones.
-Please send all bugs to <dean@cleancode.org>
+Please report all bugs using https://github.com/deanproxy/eMail/issues
 Options are described below and all are MANDITORY.
 
     --bindir dir        Specifies the directory to find the binary to remove.


### PR DESCRIPTION
Also looks like www.cleancode.org is not somewhere anyone would want to visit anymore! 

Guessing to send bugs to GitHub issues. Use  http://deanproxy.com/contact/ and  http://deanproxy.com/ for author - happy to change or revert.

There is still the title link at the top of the project page under <> Code.
