### PR TITLE
fix $cwd undefined in configure

### DIFF
--- a/configure
+++ b/configure
@@ -623,7 +623,7 @@ ac_includes_default="\
 #endif"
 
 ac_subst_vars='LTLIBOBJS
-ver
+cwd
 LIBOBJS
 SET_MAKE
 EGREP
@@ -5409,7 +5409,7 @@ else
     CFLAGS="$CFLAGS -DUSE_GNU_STRFTIME"
 fi
 
-ver="$version"
+cwd="$(pwd)"
 
 
 CFLAGS="$CFLAGS -I$cwd -I$cwd/src -I$cwd/include -I../include -I$cwd/dlib/include"

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,5 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
-cwd=`pwd`
-
 AC_PREREQ(2.60)
 AC_INIT(email, 3, <dean.nospam@dean.nospam.proxy.com>)
 AC_CONFIG_SRCDIR([src/addr_parse.c])
@@ -63,7 +61,7 @@ else
     CFLAGS="$CFLAGS -DUSE_GNU_STRFTIME"
 fi
 
-AC_SUBST(ver, ["$version"])
+AC_SUBST(cwd, ["$(pwd)"])
 
 CFLAGS="$CFLAGS -I$cwd -I$cwd/src -I$cwd/include -I../include -I$cwd/dlib/include"
 CFLAGS="$CFLAGS -I../dlib/include -DEMAIL_VERSION='\"`cat VERSION`\"' "

--- a/configure.ac
+++ b/configure.ac
@@ -65,8 +65,8 @@ fi
 
 AC_SUBST(ver, ["$version"])
 
-CFLAGS="$CFLAGS -I$cwd -I$cwd/src -I$cwd/include -I$cwd/../include -I$cwd/dlib/include"
-CFLAGS="$CFLAGS -I$cwd/../dlib/include -DEMAIL_VERSION='\"`cat VERSION`\"' "
+CFLAGS="$CFLAGS -I$cwd -I$cwd/src -I$cwd/include -I../include -I$cwd/dlib/include"
+CFLAGS="$CFLAGS -I../dlib/include -DEMAIL_VERSION='\"`cat VERSION`\"' "
 CFLAGS="$CFLAGS -DEMAIL_DIR='\"${sysconfdir}/email\"'"
 
 AC_CONFIG_FILES([Makefile


### PR DESCRIPTION
I've reused AC_SUBST for ver - didn't seem to be used?
Also reverted the previous change from https://github.com/deanproxy/eMail/pull/29. That broke compiling for me on its own. We'll see if e9523d3 is the actual fix for that issue.
