### PR TITLE
Fix default docdir

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,6 +7,7 @@ CFLAGS = @CFLAGS@ @DEFS@
 LDFLAGS = @LDFLAGS@
 LIBS = @LIBS@
 DLIB = dlib/
+PACKAGE_TARNAME=email-$(VERSION)
 
 prefix = @prefix@
 exec_prefix = @exec_prefix@

--- a/Makefile.in
+++ b/Makefile.in
@@ -28,7 +28,7 @@ all:
 install:
 	./install.sh --bindir "$(DESTDIR)$(bindir)" --sysconfdir "$(DESTDIR)$(sysconfdir)" \
 		--mandir "$(DESTDIR)$(mandir)" --binext "$(bin_suffix)" --version "$(VERSION)" \
-        --docdir "$(DESTDIR)$(docdir)/email-$(VERSION)"
+        --docdir "$(DESTDIR)$(docdir)"
 
 distclean:
 	cd $(SRCDIR) && $(MAKE) clean-all
@@ -45,6 +45,6 @@ clean-all:
 
 uninstall:
 	./uninstall.sh --bindir "$(DEST_DIR)$(bindir)" --sysconfdir "$(DEST_DIR)$(sysconfdir)" \
-	    --mandir "$(DEST_DIR)$(mandir)" --docdir "$(DEST_DIR)$(docdir)/email-$(VERSION)" --version "$(VERSION)"
+	    --mandir "$(DEST_DIR)$(mandir)" --docdir "$(DEST_DIR)$(docdir)" --version "$(VERSION)"
 
 


### PR DESCRIPTION
PR  #36 addresses a problem if --docdir is not passed to configure, but breaks the case when --docdir is used.

Default docdir is created by autoconf as ${datarootdir}/doc/${PACKAGE_TARNAME}, and the underlying cause here is that PACKAGE_TARNAME is not defined in the Makefile.

By default (set by AC_INIT) PACKAGE_TARNAME would have the value "email" but as it isn't used anywhere else it can be set to "email-$(VERSION)" if that is the desired default. (I can't see a way to modify docdir itself).
