### PR TITLE
Fix make clean rule

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -40,7 +40,7 @@ distclean:
 
 clean:
 	cd $(SRCDIR) && $(MAKE) clean
-	if [ "$(cwd)" != "$(includedir)" ]; cd $(DLIB) && $(MAKE) clean; fi
+	if [ "$(cwd)" != "$(includedir)" ]; then cd $(DLIB) && $(MAKE) clean; fi
 
 clean-all:
 	cd $(SRCDIR) && $(MAKE) clean-all

--- a/email.1.in
+++ b/email.1.in
@@ -257,7 +257,6 @@ listed below.
   MY_EMAIL          : Specify your email address
   REPLY_TO          : Seperate reply to address
   SIGNATURE_FILE    : Your signature file
-  SIGNATURE_DIVIDE  : A design for a divider
   ADDRESS_BOOK      : Location of your address book file
   SAVE_SENT_MAIL    : Directory to save email.sent file
   GPG_BIN           : Full path to gpg binary

--- a/src/email.c
+++ b/src/email.c
@@ -245,8 +245,10 @@ main(int argc, char **argv)
 		case 'a':
 			if (!Mopts.attach) {
 				Mopts.attach = dlInit(defaultDestr);
+				dlInsertTop(Mopts.attach, xstrdup(optarg));
+			} else {
+				dlInsertEnd(Mopts.attach, xstrdup(optarg));
 			}
-			dlInsertTop(Mopts.attach, xstrdup(optarg));
 			break;
 		case 'V':
 			Mopts.verbose = true;

--- a/src/email.c
+++ b/src/email.c
@@ -349,8 +349,10 @@ main(int argc, char **argv)
 		dstrbuf *vcard = expandPath(getConfValue("VCARD"));
 		if (!Mopts.attach) {
 			Mopts.attach = dlInit(defaultDestr);
+			dlInsertTop(Mopts.attach, xstrdup(vcard->str));
+		} else {
+			dlInsertEnd(Mopts.attach, xstrdup(vcard->str));
 		}
-		dlInsertTop(Mopts.attach, xstrdup(vcard->str));
 		dsbDestroy(vcard);
 	}
 


### PR DESCRIPTION
The make clean rule was missing a "then", so it wouldn't run properly.
This commit adds it, so now it works as it should.