### PR TITLE
email: fix build against gcc-10 (-fno-common)

### DIFF
--- a/include/email.h
+++ b/include/email.h
@@ -60,11 +60,11 @@ struct addr {
 typedef enum { GPG_SIG=0x01, GPG_ENC=0x02 } GpgCallType;
 
 
-/* Globally defined vars */
-dhash table;
-char *conf_file;
+/* Globally declared vars */
+extern dhash table;
+extern char *conf_file;
 
-struct mailer_options {
+extern struct mailer_options {
 	bool verbose;
 	bool encoding;
 	short html;

--- a/src/email.c
+++ b/src/email.c
@@ -40,6 +40,11 @@
 #include "error.h"
 #include "mimeutils.h"
 
+/* Globally defined vars */
+dhash table;
+char *conf_file;
+struct mailer_options Mopts;
+
 static void
 defaultDestr(void *ptr)
 {


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: utils.o:include/email.h:81: multiple definition of `Mopts'; email.o:include/email.h:81: first defined here
    ld: utils.o:include/email.h:64: multiple definition of `table'; email.o:include/email.h:64: first defined here
    ld: utils.o:include/email.h:65: multiple definition of `conf_file'; email.o:include/email.h:65: first defined here

The change moves globals definitions from include/email.h files to src/email.c.