### PR TITLE
Import ctype.h in check_strftime.sh

### DIFF
--- a/check_strftime.sh
+++ b/check_strftime.sh
@@ -14,6 +14,7 @@ cat << EOF > /tmp/strftime_try.c
 #include <stdlib.h>
 #include <time.h>
 #include <sys/time.h>
+#include <ctype.h>
 
 int
 main (void)


### PR DESCRIPTION
Clang16 will not allow  -Wimplicit-function-declaration will results in the error
```
checking if strftime is GNU or Non-GNU... /tmp/strftime_try.c:16:8: error: call to undeclared library function 'isdigit' with type
      'int (int)'; ISO C99 and later do not support implicit function declarations
      [-Werror,-Wimplicit-function-declaration]
  if (!isdigit(buf[1]))
       ^
```
during configure. While this does not stop the configure, it could result in unexpected behavior. 
It's enough to import the right library into this check. 

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>